### PR TITLE
Add rich support and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,11 @@ user who want to save cost and want to scale base on usage without administrativ
     $ python deploy.py $BENTO_BUNDLE_PATH my-lambda-deployment lambda_config.json
 
     # Sample output
-    Creating AWS Lambda deployable
-    Building SAM template
-    Building Image
-    0
-    Build Succeeded
-    Built Artifacts
-    ...
-    CloudFormation outputs from deployed stack
-    -------------------------------------------------------------------------------------------------
-    Outputs
-    -------------------------------------------------------------------------------------------------
-    Key                 EndpointUrl
-    Description         URL for endpoint
-    Value               https://j2gm5zn7z9.execute-api.us-west-1.amazonaws.com/Prod
-    -------------------------------------------------------------------------------------------------
-
-    Successfully created/updated stack - my-lambda-deployment-stack in us-west-1
+    Created AWS Lambda deployable [./IrisClassifier-20210817110233_99D507-lambda-deployable]
+    Built SAM template [./IrisClassifier-20210817110233_99D507-lambda-deployable/template.yaml]
+    Image built and pushed [1111111111.dkr.ecr.ap-south-1.amazonaws.com/iristest-repo]
+    Deployment Complete!
+    ```
 
 3. Get deployment information and status
 
@@ -57,12 +45,12 @@ $ python describe.py my-lambda-deployment
 
 # Sample output
 {
-  "StackId": "arn:aws:cloudformation:us-west-1:192023623294:stack/my-lambda-deployment-stack/29c15040-db7a-11eb-a721-028d528946df",
-  "StackName": "my-lambda-deployment-stack",
-  "StackStatus": "CREATE_COMPLETE",
-  "CreationTime": "07/02/2021, 21:12:09",
-  "LastUpdatedTime": "07/02/2021, 21:12:20",
-  "EndpointUrl": "https://j2gm5zn7z9.execute-api.us-west-1.amazonaws.com/Prod"
+   'StackId': 'arn:aws:cloudformation:ap-south-1:213386773652:stack/iristest-stack/ed94eac0-016f-11ec-aa25-066514cd8e28',
+   'StackName': 'iristest-stack',
+   'StackStatus': 'CREATE_COMPLETE',
+   'CreationTime': '08/20/2021, 04:34:38',
+   'LastUpdatedTime': '08/20/2021, 04:34:43',
+   'EndpointUrl': 'https://l7layje3l9.execute-api.ap-south-1.amazonaws.com/Prod'
 }
 ```
 
@@ -97,8 +85,9 @@ x-amz-cf-id: ArwZ03gbs6GooNN1fy4mPOgaEpM4h4n9gz2lpLYrHmeXZJuGUJgz0Q==
 $ python delete.py my-lambda-deployment
 
 # Sample output
-Delete CloudFormation Stack my-lambda-deployment-stack
-Delete ECR repo my-lambda-deployment-repo
+Deleted CloudFormation Stack: iristest-stack
+Deleted ECR repo: iristest-repo
+Deletion Complete!
 ```
 
 ## Deployment operations
@@ -176,3 +165,7 @@ Use Python API
 from  delete import delete_deployment
 delete_deployment(DEPLOYMENT_NAME, CONFIG_JSON)
 ```
+
+## Notes
+1. Currently the lambda deployment doesnot support `FileInput` handler. If you want to upload files to your bentoservice deployed on lambda, you can encode the binary data with base64 and then pass it via the `JsonInput` handler (you can also sent mulitple files this way).
+2. `multipart/form-data` is not supported in lambda deployments. The workaround will also be to use the `JsonInput` handler and add the base64 encoded files as different json value pairs

--- a/aws_lambda/__init__.py
+++ b/aws_lambda/__init__.py
@@ -5,10 +5,15 @@ from pathlib import Path
 import subprocess
 
 from bentoml.utils.ruamel_yaml import YAML
+from utils import is_present
 
 
 def generate_lambda_deployable(bento_bundle_path, project_path, lambda_config):
     current_dir_path = os.path.dirname(__file__)
+
+    # is existing repo is found and user said not to overide, use existing deployable
+    if is_present(project_path):
+        return
 
     # copy bento_bundle to project_path
     shutil.copytree(bento_bundle_path, project_path)

--- a/delete.py
+++ b/delete.py
@@ -3,21 +3,21 @@ import boto3
 from botocore.exceptions import ClientError
 
 from aws_lambda import generate_lambda_resource_names
-from utils import get_configuration_value
+from utils import get_configuration_value, console
 
 
-def delete_aws_lambda(deployment_name, config_json):
+def delete(deployment_name, config_json):
     lambda_config = get_configuration_value(config_json)
     _, stack_name, repo_name = generate_lambda_resource_names(deployment_name)
     cf_client = boto3.client("cloudformation", lambda_config["region"])
-    print(f"Delete CloudFormation Stack {stack_name}")
     cf_client.delete_stack(StackName=stack_name)
+    print(f"Deleted CloudFormation Stack: {stack_name}")
 
     # delete ecr repository
     ecr_client = boto3.client("ecr", lambda_config["region"])
     try:
-        print(f"Delete ECR repo {repo_name}")
         ecr_client.delete_repository(repositoryName=repo_name, force=True)
+        print(f"Deleted ECR repo: {repo_name}")
     except ClientError as e:
         # raise error, if the repo can't be found
         if e.response and e.response["Error"]["Code"] != "RepositoryNotFoundException":
@@ -32,4 +32,5 @@ if __name__ == "__main__":
     deployment_name = sys.argv[1]
     config_json = sys.argv[2] if len(sys.argv) == 3 else "lambda_config.json"
 
-    delete_aws_lambda(deployment_name, config_json)
+    delete(deployment_name, config_json)
+    console.print("[bold green]Deletion Complete!")

--- a/deploy.py
+++ b/deploy.py
@@ -6,6 +6,7 @@ from bentoml.saved_bundle import load_bento_service_metadata
 from utils import (
     get_configuration_value,
     create_ecr_repository_if_not_exists,
+    console,
 )
 from aws_lambda import (
     generate_lambda_deployable,
@@ -15,7 +16,7 @@ from aws_lambda import (
 )
 
 
-def deploy_aws_lambda(bento_bundle_path, deployment_name, config_json):
+def deploy(bento_bundle_path, deployment_name, config_json):
     bento_metadata = load_bento_service_metadata(bento_bundle_path)
     lambda_config = get_configuration_value(config_json)
     deployable_path = os.path.join(
@@ -23,15 +24,14 @@ def deploy_aws_lambda(bento_bundle_path, deployment_name, config_json):
         f"{bento_metadata.name}-{bento_metadata.version}-lambda-deployable",
     )
 
-    print("Creating AWS Lambda deployable")
     generate_lambda_deployable(bento_bundle_path, deployable_path, lambda_config)
     (
         template_name,
         stack_name,
         repo_name,
     ) = generate_lambda_resource_names(deployment_name)
+    console.print(f"Created AWS Lambda deployable [b][{deployable_path}][/b]")
 
-    print("Building SAM template")
     api_names = [api.name for api in bento_metadata.apis]
     template_file_path = generate_aws_lambda_cloudformation_template_file(
         deployment_name=deployment_name,
@@ -44,60 +44,62 @@ def deploy_aws_lambda(bento_bundle_path, deployment_name, config_json):
         memory_size=lambda_config["memory_size"],
         timeout=lambda_config["timeout"],
     )
+    console.print(f"Built SAM template [b][{template_file_path}][/b]")
 
-    print("Building Image")
-    return_code, stdout, stderr = call_sam_command(
-        [
-            "build",
-            "--template-file",
-            template_file_path.split("/")[-1],
-            "--build-dir",
-            os.path.join(deployable_path, "build"),
-        ],
-        project_dir=deployable_path,
-        region=lambda_config["region"],
-    )
-    # print(return_code, stdout, stderr)
+    with console.status("Building image"):
+        return_code, stdout, stderr = call_sam_command(
+            [
+                "build",
+                "--template-file",
+                template_file_path.split("/")[-1],
+                "--build-dir",
+                os.path.join(deployable_path, "build"),
+            ],
+            project_dir=deployable_path,
+            region=lambda_config["region"],
+        )
+        # print(return_code, stdout, stderr)
 
-    print("Pushing Image to ECR")
-    repository_id, registry_url = create_ecr_repository_if_not_exists(
-        lambda_config["region"], repo_name
-    )
-    return_code, stdout, stderr = call_sam_command(
-        [
-            "package",
-            "--template-file",
-            os.path.join(deployable_path, "build", "template.yaml"),
-            "--output-template-file",
-            "package-template.yaml",
-            "--image-repository",
-            registry_url,
-        ],
-        project_dir=deployable_path,
-        region=lambda_config["region"],
-    )
-    # print(return_code, stdout, stderr)
+    with console.status("Pushing image to ECR"):
+        repository_id, registry_url = create_ecr_repository_if_not_exists(
+            lambda_config["region"], repo_name
+        )
+        return_code, stdout, stderr = call_sam_command(
+            [
+                "package",
+                "--template-file",
+                os.path.join(deployable_path, "build", "template.yaml"),
+                "--output-template-file",
+                "package-template.yaml",
+                "--image-repository",
+                registry_url,
+            ],
+            project_dir=deployable_path,
+            region=lambda_config["region"],
+        )
+        # print(return_code, stdout, stderr)
+    console.print(f"Image built and pushed [b][{registry_url}][/b]")
 
-    print("Deploying the Image")
-    return_code, stdout, stderr = call_sam_command(
-        [
-            "deploy",
-            "-t",
-            "package-template.yaml",
-            "--stack-name",
-            stack_name,
-            "--image-repository",
-            registry_url,
-            "--capabilities",
-            "CAPABILITY_IAM",
-            "--region",
-            lambda_config["region"],
-            "--no-confirm-changeset",
-        ],
-        project_dir=deployable_path,
-        region=lambda_config["region"],
-    )
-    # print(return_code, stdout, stderr)
+    with console.status("Deploying to Lambda"):
+        return_code, stdout, stderr = call_sam_command(
+            [
+                "deploy",
+                "-t",
+                "package-template.yaml",
+                "--stack-name",
+                stack_name,
+                "--image-repository",
+                registry_url,
+                "--capabilities",
+                "CAPABILITY_IAM",
+                "--region",
+                lambda_config["region"],
+                "--no-confirm-changeset",
+            ],
+            project_dir=deployable_path,
+            region=lambda_config["region"],
+        )
+        # print(return_code, stdout, stderr)
 
 
 if __name__ == "__main__":
@@ -110,4 +112,5 @@ if __name__ == "__main__":
     deployment_name = sys.argv[2]
     config_json = sys.argv[3] if len(sys.argv) == 4 else "lambda_config.json"
 
-    deploy_aws_lambda(bento_bundle_path, deployment_name, config_json)
+    deploy(bento_bundle_path, deployment_name, config_json)
+    console.print("[bold green]Deployment Complete!")

--- a/describe.py
+++ b/describe.py
@@ -5,9 +5,10 @@ from botocore.exceptions import ClientError
 
 from aws_lambda import generate_lambda_resource_names
 from utils import get_configuration_value
+from rich.pretty import pprint
 
 
-def describe_lambda_deployment(deployment_name, config_file_path):
+def describe(deployment_name, config_file_path):
     # get data about cf stack
     _, stack_name, repo_name = generate_lambda_resource_names(deployment_name)
     lambda_config = get_configuration_value(config_file_path)
@@ -49,5 +50,5 @@ if __name__ == "__main__":
     deployment_name = sys.argv[1]
     config_json = sys.argv[3] if len(sys.argv) == 4 else "lambda_config.json"
 
-    info_json = describe_lambda_deployment(deployment_name, config_json)
-    print(json.dumps(info_json, indent=2))
+    info_json = describe(deployment_name, config_json)
+    pprint(info_json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bentoml
 boto3
 aws-sam-cli
 pandas
+rich

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,6 @@ import os
 import sys
 import shutil
 import tempfile
-import urllib
 import time
 
 import requests
@@ -11,9 +10,9 @@ from pandas import DataFrame
 from classifier import TestService
 
 sys.path.append("./")
-from deploy import deploy_aws_lambda
-from describe import describe_lambda_deployment
-from delete import delete_aws_lambda
+from deploy import deploy
+from describe import describe
+from delete import delete
 
 
 class Setup:
@@ -45,8 +44,8 @@ class Setup:
         test_service.save_to_dir(self.saved_dir)
 
     def make_deployment(self):
-        deploy_aws_lambda(self.saved_dir, self.deployment_name, self.config_file)
-        info_json = describe_lambda_deployment(self.deployment_name, self.config_file)
+        deploy(self.saved_dir, self.deployment_name, self.config_file)
+        info_json = describe(self.deployment_name, self.config_file)
         url = info_json["EndpointUrl"] + "/{}"
 
         # ping /healthz to check if deployment is up
@@ -59,7 +58,7 @@ class Setup:
         return url
 
     def teardown(self):
-        delete_aws_lambda(self.deployment_name, self.config_file)
+        delete(self.deployment_name, self.config_file)
         shutil.rmtree(self.dirpath)
         print("Removed {}!".format(self.dirpath))
 

--- a/update.py
+++ b/update.py
@@ -1,108 +1,16 @@
 import sys
-import os
 
-from bentoml.saved_bundle import load_bento_service_metadata
-
-from utils import (
-    get_configuration_value,
-    create_ecr_repository_if_not_exists,
-    build_docker_image,
-    push_docker_image_to_repository,
-    get_ecr_login_info,
-    generate_docker_image_tag,
-)
-from aws_lambda import (
-    generate_lambda_deployable,
-    generate_lambda_resource_names,
-    generate_aws_lambda_cloudformation_template_file,
-    call_sam_command,
-)
+from utils import console
+from deploy import deploy
 
 
-def update_aws_lambda(bento_bundle_path, deployment_name, config_json):
-    bento_metadata = load_bento_service_metadata(bento_bundle_path)
-    lambda_config = get_configuration_value(config_json)
-    deployable_path = os.path.join(
-        os.path.curdir,
-        f"{bento_metadata.name}-{bento_metadata.version}-lambda-deployable",
-    )
-
-    print("Creating AWS Lambda deployable")
-    generate_lambda_deployable(bento_bundle_path, deployable_path, lambda_config)
-    (
-        template_name,
-        stack_name,
-        repo_name,
-    ) = generate_lambda_resource_names(deployment_name)
-
-    print("Building SAM template")
-    api_names = [api.name for api in bento_metadata.apis]
-    template_file_path = generate_aws_lambda_cloudformation_template_file(
-        deployment_name=deployment_name,
-        project_dir=deployable_path,
-        api_names=api_names,
-        bento_service_name=bento_metadata.name,
-        docker_context=deployable_path,
-        docker_file="Dockerfile-lambda",
-        docker_tag=repo_name,
-        memory_size=lambda_config["memory_size"],
-        timeout=lambda_config["timeout"],
-    )
-
-    print("Building Image")
-    return_code, stdout, stderr = call_sam_command(
-        [
-            "build",
-            "--template-file",
-            template_file_path.split("/")[-1],
-            "--build-dir",
-            os.path.join(deployable_path, "build"),
-        ],
-        project_dir=deployable_path,
-        region=lambda_config["region"],
-    )
-    # print(return_code, stdout, stderr)
-
-    print("Pushing Image to ECR")
-    repository_id, registry_url = create_ecr_repository_if_not_exists(
-        lambda_config["region"], repo_name
-    )
-    return_code, stdout, stderr = call_sam_command(
-        [
-            "package",
-            "--template-file",
-            os.path.join(deployable_path, "build", "template.yaml"),
-            "--output-template-file",
-            "package-template.yaml",
-            "--image-repository",
-            registry_url,
-        ],
-        project_dir=deployable_path,
-        region=lambda_config["region"],
-    )
-    # print(return_code, stdout, stderr)
-
-    print("Updating stack")
-    return_code, stdout, stderr = call_sam_command(
-        [
-            "deploy",
-            "-t",
-            "package-template.yaml",
-            "--stack-name",
-            stack_name,
-            "--image-repository",
-            registry_url,
-            "--capabilities",
-            "CAPABILITY_IAM",
-            "--region",
-            lambda_config["region"],
-            "--no-confirm-changeset",
-        ],
-        project_dir=deployable_path,
-        region=lambda_config["region"],
-    )
-    # print(return_code, stdout, stderr)
-
+def update(bento_bundle_path, deployment_name, config_json):
+    """
+    in the case of AWS Lambda deployments, since we are using SAM cli for deploying
+    the updation and deployment process is identical, hence you can just call the
+    deploy functionality for updation also.
+    """
+    deploy(bento_bundle_path, deployment_name, config_json)
 
 
 if __name__ == "__main__":
@@ -112,4 +20,5 @@ if __name__ == "__main__":
     deployment_name = sys.argv[2]
     config_json = sys.argv[3] if len(sys.argv) == 4 else "lambda_config.json"
 
-    update_aws_lambda(bento_bundle_path, deployment_name, config_json)
+    update(bento_bundle_path, deployment_name, config_json)
+    console.print("[bold green]Updation Complete!")


### PR DESCRIPTION
### Notable changes

- deleted most of update.py - the code for updation was redundant with deploy since we use SAM CLI behind and in that they use `deploy` for both updation and deployment. Our codebase for updation was just of copy of deploy, hence removing it for better maintainability 
- added rich support - UI and all has been improved
- Changed function names to deploy, update, describe, delete instead of older, more specific names. This help abstract the specifics of each particular operation for bentoml deployment operations from the vendor-specific parts. 