### PR TITLE
refactor lambda

### DIFF
--- a/bentoctl_lambda/aws_lambda/Dockerfile.template
+++ b/bentoctl_lambda/aws_lambda/Dockerfile.template
@@ -1,6 +1,4 @@
-ARG BENTOML_VERSION=1.0.0a1
-ARG PYTHON_VERSION=3.8
-FROM bentoml/bento-server:$BENTOML_VERSION-python$PYTHON_VERSION-debian-runtime
+FROM bentoml/bento-server:{bentoml_version}-python{python_version}-debian-runtime
 
 ARG UID=1034
 ARG GID=1034

--- a/bentoctl_lambda/aws_lambda/__init__.py
+++ b/bentoctl_lambda/aws_lambda/__init__.py
@@ -123,6 +123,7 @@ def generate_aws_lambda_cloudformation_template_file(
         "Globals": {
             "Function": {"Timeout": timeout, "MemorySize": memory_size},
             "Api": {
+                "BinaryMediaTypes": ["*~1*"],
                 "Cors": "'*'",
                 "Auth": {
                     "ApiKeyRequired": False,

--- a/bentoctl_lambda/aws_lambda/app.py
+++ b/bentoctl_lambda/aws_lambda/app.py
@@ -5,10 +5,10 @@ from bentoml import load
 from mangum import Mangum
 
 api_name = os.environ["BENTOML_API_NAME"]
-print('loading app: ', api_name)
-print('Loading from dir...')
-bento_service = load('./')
-print('bento service', bento_service)
+print("loading app: ", api_name)
+print("Loading from dir...")
+bento_service = load("./")
+print("bento service", bento_service)
 # bento_service_api = bento_service.get_inference_api(api_name)
 
 this_module = sys.modules[__name__]

--- a/bentoctl_lambda/deploy.py
+++ b/bentoctl_lambda/deploy.py
@@ -34,7 +34,7 @@ def deploy(bento_path, deployment_name, deployment_spec):
     template_file_path = generate_aws_lambda_cloudformation_template_file(
         deployment_name=deployment_name,
         project_dir=deployable_path,
-        api_names=list(bento_svc._apis),
+        api_names=list(bento_svc.apis),
         bento_service_name=bento_svc.name,
         docker_context=deployable_path,
         docker_file="Dockerfile-lambda",

--- a/bentoctl_lambda/utils/__init__.py
+++ b/bentoctl_lambda/utils/__init__.py
@@ -154,6 +154,17 @@ def generate_docker_image_tag(registry_uri, bento_name, bento_version):
     return f"{registry_uri}:{image_tag}"
 
 
-def get_tag_from_path(path: str):
+def get_metadata(path: str):
+    metadata = {}
+
     bento = Bento.from_fs(fs.open_fs(path))
-    return bento.tag
+    metadata["tag"] = bento.tag
+    metadata["bentoml_version"] = ".".join(bento.info.bentoml_version.split(".")[:3])
+
+    python_version_txt_path = "env/python/version.txt"
+    python_version_txt_path = os.path.join(path, python_version_txt_path)
+    with open(python_version_txt_path, "r") as f:
+        python_version = f.read()
+    metadata["python_version"] = ".".join(python_version.split(".")[:2])
+
+    return metadata


### PR DESCRIPTION
- Lambda image is now taken based on the python version and bento version used
- API gateway proxies all the requests to lambda in binary format 