### PR TITLE
feat: use bentoml config to disable prometheus

### DIFF
--- a/bentoctl_lambda/aws_lambda/README.md
+++ b/bentoctl_lambda/aws_lambda/README.md
@@ -1,0 +1,30 @@
+AWS Lambda supports deployment via containers of upto 10gb and that is what we
+are using for deploying bentos into lambda. The docs can be accessed
+[here](https://docs.aws.amazon.com/lambda/latest/dg/images-create.html).
+
+In order for AWS to run the container in lambda they require the following
+- Defining a handler: this is the python code that will handle the `event` and
+  `context` dict that is passed when ever the lambda function is invoked. Our
+  handler is defined in ./app.py and it uses
+  [Mangum](https://github.com/jordaneremieff/mangum) to handle the incoming
+  requrest. 
+- setup aws-lambda-ric: this is the runtime-interface-client that AWS has
+  developed to interface with the Runtime API
+  (https://github.com/aws/aws-lambda-python-runtime-interface-client). The
+  ./entry_script.sh handles invoking and loading the handler with the RIC.
+
+## Terraform setup
+
+AWS lambda is setup with an HTTP API infront to act as public endpoint for the
+lambda function. Any request that comes is passed onto the lambda function. The
+request is handled by mangum which transforms it into a ASGI request that can be
+processed by bentoml's ASGI app. 
+
+All the logs are in cloudwatch and IAM policies for every infra is created by
+the terraform template.
+
+## Dev setup
+
+Right now running it locally is not possible. There is a lambda Runtime Emulator
+that loads any handler and emulates the AWS interface but it is still work in
+progress.

--- a/bentoctl_lambda/aws_lambda/app.py
+++ b/bentoctl_lambda/aws_lambda/app.py
@@ -1,7 +1,6 @@
 import os
 
 from bentoml import load
-from bentoml._internal.configuration.containers import DeploymentContainer
 from mangum import Mangum
 
 API_GATEWAY_STAGE = os.environ.get("API_GATEWAY_STAGE", None)
@@ -9,7 +8,4 @@ print("Loading from dir...")
 bento_service = load("./")
 print("bento service", bento_service)
 
-# Disable /metrics endpoint since promethues is not configured for use
-# in lambda
-DeploymentContainer.api_server_config.metrics.enabled.set(False)
 mangum_app = Mangum(bento_service.asgi_app, api_gateway_base_path=API_GATEWAY_STAGE)

--- a/bentoctl_lambda/aws_lambda/bentoml_server_config.yaml
+++ b/bentoctl_lambda/aws_lambda/bentoml_server_config.yaml
@@ -1,0 +1,3 @@
+bento_server:
+  metrics:
+    enabled: False

--- a/bentoctl_lambda/aws_lambda/bentoml_server_config.yaml
+++ b/bentoctl_lambda/aws_lambda/bentoml_server_config.yaml
@@ -1,3 +1,3 @@
-bento_server:
+api_server:
   metrics:
     enabled: False

--- a/bentoctl_lambda/aws_lambda/entry_script.sh
+++ b/bentoctl_lambda/aws_lambda/entry_script.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+  exec /usr/local/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric $@
+else
+  exec /usr/local/bin/python -m awslambdaric $@
+fi     

--- a/bentoctl_lambda/aws_lambda/template.j2
+++ b/bentoctl_lambda/aws_lambda/template.j2
@@ -2,11 +2,16 @@
 {% set bento__home = "/tmp" %}
 {% block SETUP_BENTO_ENTRYPOINT %}
 EXPOSE 3000
+ENV BENTOML_CONFIG={{bento__path}}/bentoml_config.yaml
 
 RUN --mount=type=cache,from=cached,mode=0777,target=/root/.cache/pip \
 	pip install awslambdaric==2.0.0 mangum==0.12.3
 
 USER root
-
-ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+ADD ./aws-lambda-rie /usr/local/bin/aws-lambda-rie
+RUN chmod +x /usr/local/bin/aws-lambda-rie
+RUN chmod +x {{bento__path}}/env/docker/entry_script.sh
+ENTRYPOINT ["{{ 
+    expands_bento_path("env", "docker", "entry_script.sh", bento_path=bento__path)
+    }}"]
 {% endblock %}

--- a/bentoctl_lambda/aws_lambda/template.j2
+++ b/bentoctl_lambda/aws_lambda/template.j2
@@ -11,7 +11,5 @@ USER root
 ADD ./aws-lambda-rie /usr/local/bin/aws-lambda-rie
 RUN chmod +x /usr/local/bin/aws-lambda-rie
 RUN chmod +x {{bento__path}}/env/docker/entry_script.sh
-ENTRYPOINT ["{{ 
-    expands_bento_path("env", "docker", "entry_script.sh", bento_path=bento__path)
-    }}"]
+ENTRYPOINT ["{{bento__path}}/env/docker/entry_script.sh"]
 {% endblock %}

--- a/bentoctl_lambda/create_deployable.py
+++ b/bentoctl_lambda/create_deployable.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import os
 import shutil
-from sys import version_info
 from pathlib import Path
-from attr import asdict
+from sys import version_info
 from typing import Any
+
+from attr import asdict
 
 if version_info >= (3, 8):
     from shutil import copytree
@@ -19,6 +20,9 @@ from bentoml._internal.bento.gen import generate_dockerfile
 LAMBDA_DIR = Path(os.path.dirname(__file__), "aws_lambda")
 TEMPLATE_PATH = LAMBDA_DIR.joinpath("template.j2")
 APP_PATH = LAMBDA_DIR.joinpath("app.py")
+ENTRY_SCRIPT = LAMBDA_DIR.joinpath("entry_script.sh")
+AWS_LAMBDA_RIE = LAMBDA_DIR.joinpath("aws-lambda-rie-x86")
+BENTOML_CONFIG_FILE = LAMBDA_DIR.joinpath("bentoml_server_config.yaml")
 
 
 def create_deployable(
@@ -49,11 +53,6 @@ def create_deployable(
     deployable_path = Path(destination_dir)
     copytree(bento_path, deployable_path, dirs_exist_ok=True)
 
-    if deployable_path.exists():
-        if not overwrite_deployable:
-            print("Using existing deployable")
-            return str(deployable_path)
-
     bento_metafile = Path(bento_path, "bento.yaml")
     with bento_metafile.open("r", encoding="utf-8") as metafile:
         info = BentoInfo.from_yaml_file(metafile)
@@ -63,15 +62,32 @@ def create_deployable(
 
     dockerfile_path = deployable_path.joinpath("env", "docker", "Dockerfile")
     with dockerfile_path.open("w", encoding="utf-8") as dockerfile:
-        dockerfile.write(
-            generate_dockerfile(
-                DockerOptions(**options).with_defaults(),
-                str(deployable_path),
-                use_conda=not info.conda.is_empty(),
-            )
+        dockerfile_generated = generate_dockerfile(
+            DockerOptions(**options).with_defaults(),
+            str(deployable_path),
+            use_conda=not info.conda.is_empty(),
         )
+        dockerfile.write(dockerfile_generated)
 
     # copy over app.py file
     shutil.copy(str(APP_PATH), os.path.join(deployable_path, "app.py"))
+
+    # the entry_script.sh file that will be the entrypoint
+    shutil.copy(
+        str(ENTRY_SCRIPT),
+        os.path.join(deployable_path, "env", "docker", "entry_script.sh"),
+    )
+
+    # aws-lambda runtime-interface-emulator - check docs for more info
+    shutil.copy(
+        str(AWS_LAMBDA_RIE),
+        os.path.join(deployable_path, "aws-lambda-rie"),
+    )
+
+    # bentoml_config_file
+    shutil.copy(
+        str(BENTOML_CONFIG_FILE),
+        os.path.join(deployable_path, "bentoml_config.yaml"),
+    )
 
     return str(deployable_path)

--- a/bentoctl_lambda/create_deployable.py
+++ b/bentoctl_lambda/create_deployable.py
@@ -84,7 +84,7 @@ def create_deployable(
         os.path.join(deployable_path, "aws-lambda-rie"),
     )
 
-    # bentoml_config_file
+    # bentoml_config_file to dissable /metrics
     shutil.copy(
         str(BENTOML_CONFIG_FILE),
         os.path.join(deployable_path, "bentoml_config.yaml"),


### PR DESCRIPTION
- disable Prometheus
- attach a Lambda Runtime Emulator to the image. This will help lambda image work locally since it is emulating the environment. This would help in faster development and testing 