### PR TITLE
fix: using standalone_load flag

### DIFF
--- a/bentoctl_lambda/aws_lambda/app.py
+++ b/bentoctl_lambda/aws_lambda/app.py
@@ -4,8 +4,10 @@ from bentoml import load
 from mangum import Mangum
 
 API_GATEWAY_STAGE = os.environ.get("API_GATEWAY_STAGE", None)
+
 print("Loading from dir...")
-bento_service = load("./")
+bento_service = load("./", standalone_load=True)
+
 print("bento service", bento_service)
 
 mangum_app = Mangum(bento_service.asgi_app, api_gateway_base_path=API_GATEWAY_STAGE)


### PR DESCRIPTION
fixes the same issue as https://github.com/bentoml/aws-sagemaker-deploy/issues/43 for the `aws-lambda` operators