### PR TITLE
Upgrade awslambdaric to v2.0.8 to fix Docker build

### DIFF
--- a/bentoctl_lambda/aws_lambda/template.j2
+++ b/bentoctl_lambda/aws_lambda/template.j2
@@ -4,7 +4,7 @@
 EXPOSE 3000
 ENV BENTOML_CONFIG={{bento__path}}/bentoml_config.yaml
 
-RUN {{ common.mount_cache("/root/.cache/pip") }} pip install awslambdaric==2.0.0 mangum==0.12.3
+RUN {{ common.mount_cache("/root/.cache/pip") }} pip install awslambdaric==2.0.8 mangum==0.12.3
 
 USER root
 ADD ./aws-lambda-rie /usr/local/bin/aws-lambda-rie


### PR DESCRIPTION
Described in issue https://github.com/bentoml/aws-lambda-deploy/issues/49, this repo currently uses `awslambdaric==2.0.0` in the Dockerfile template, which causes `bentoctl build` to fail.

Upgrading `awslambdaric` to the latest version, v2.0.8, resolves this issue due to a fix in the `awslambdaric` repo removing `importlib-metadata` as a dependency.

Contributing this PR so that it can be fixed for anyone else who uses this operator. Let me know if I'm missing anything!